### PR TITLE
Disable `indent` rule to not conflict with prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Apart from the basic rules from the configs, we also use these additional rules:
   'react/no-unused-prop-types': 'error',
   'react/prefer-stateless-function': 'off',
   'react/prop-types': ['error', { skipUndeclared: true }],
-  indent: ['error', 2, { SwitchCase: 1 }],
+  indent: "off",
   quotes: ['error', 'single', { avoidEscape: true }],
   semi: ['warn', 'never'],
   'no-unused-vars': [
@@ -95,11 +95,11 @@ Plugins:
 
 Envs:
 
-```json
+```js
 env: {
   browser: true,
   es6: true,
   jest: true,
   node: true,
-},
+}
 ```

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
     'react/no-unused-prop-types': 'error',
     'react/prefer-stateless-function': 'off',
     'react/prop-types': ['error', { skipUndeclared: true }],
-    indent: ['error', 2, { SwitchCase: 1 }],
+    indent: 'off',
     quotes: ['error', 'single', { avoidEscape: true }],
     semi: ['warn', 'never'],
     'no-unused-vars': [


### PR DESCRIPTION
As we are using `eslint-config-prettier`, we should remove `indent` to not create conflicts